### PR TITLE
fix(permissions): use admin aad group for project admins

### DIFF
--- a/modules/azure-devops-permissions/main.tf
+++ b/modules/azure-devops-permissions/main.tf
@@ -43,6 +43,6 @@ data "azuredevops_group" "admins" {
 resource "azuredevops_group_membership" "admins" {
   group = data.azuredevops_group.admins.descriptor
   members = [
-    azuredevops_group.team_group.descriptor
+    azuredevops_group.admins_group.descriptor
   ]
 }


### PR DESCRIPTION
Fixing a bug where the wrong AAD group is given elevated permissions. Only the `-admin` AAD group subset should have Project Administrator permissions.
